### PR TITLE
Fix audience label handling

### DIFF
--- a/src/components/BulletinPreview.tsx
+++ b/src/components/BulletinPreview.tsx
@@ -17,6 +17,7 @@ const audienceLabels = {
   youth: 'Youth',
   primary: 'Primary',
   stake: 'Stake',
+  other: 'Other',
 };
 const audienceOrder = [
   'ward',
@@ -27,6 +28,7 @@ const audienceOrder = [
   'youth',
   'primary',
   'stake',
+  'other',
 ];
 
 export default function BulletinPreview({ data, hideTabs = false }: BulletinPreviewProps) {


### PR DESCRIPTION
## Summary
- add missing `other` audience option in `BulletinPreview`

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687d393bdf78832aa09e29351024fa9b