### PR TITLE
Handle pending draft after auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -948,12 +948,16 @@ function App() {
         )}
 
         {/* Auth Modal */}
-        <AuthModal 
+        <AuthModal
           isOpen={showAuthModal}
           onClose={() => setShowAuthModal(false)}
-          onAuthSuccess={() => {
+          onAuthSuccess={async () => {
             setShowAuthModal(false);
-            // Optionally auto-save the current bulletin after successful auth
+            const draft = await robustService.restoreDraftAfterAuth();
+            if (draft) {
+              setBulletinData(draft);
+              await handleSaveBulletin();
+            }
           }}
         />
 


### PR DESCRIPTION
## Summary
- auto-save any pending draft after auth success

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d3ab0db08832ab816034f9f17a17a