### PR TITLE
fix preview agenda label

### DIFF
--- a/src/components/BulletinPreview.tsx
+++ b/src/components/BulletinPreview.tsx
@@ -198,7 +198,7 @@ export default function BulletinPreview({ data, hideTabs = false }: BulletinPrev
             ) : item.type === 'musical' ? (
               <div key={item.id} className="space-y-1">
                 <DottedLine rightAlign={item.hymnNumber || item.songName}>
-                  <span>Musical Number</span>
+                  <span>{item.label || 'Musical Number'}</span>
                 </DottedLine>
                 {(item.hymnNumber || item.hymnTitle) && (
                   <div className="text-center py-1">


### PR DESCRIPTION
## Summary
- use the agenda item's label in the program preview

## Testing
- `npm run lint` *(fails: 84 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687d49428afc832abb258e45d261ee96