### PR TITLE
Handle timeout errors for tokens

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -141,17 +141,25 @@ export const tokenService = {
 
     console.log('Saving token:', { userId, key, valueLength: value.length });
 
-    const { data, error } = await supabase
-      .from('tokens')
-      .upsert({
-        key,
-        value,
-        created_by: userId
-      }, {
-        onConflict: 'key,created_by'
-      })
-      .select()
-      .single();
+    let data, error;
+    try {
+      ({ data, error } = await withTimeout(
+        supabase
+          .from('tokens')
+          .upsert({
+            key,
+            value,
+            created_by: userId
+          }, {
+            onConflict: 'key,created_by'
+          })
+          .select()
+          .single()
+      ));
+    } catch (timeoutError) {
+      console.error('Token save timed out:', timeoutError);
+      throw timeoutError;
+    }
     
     if (error) {
       console.error('Token save error:', error);
@@ -164,15 +172,25 @@ export const tokenService = {
   async getToken(userId: string, key: string): Promise<string | null> {
     if (!supabase) throw new Error('Supabase not configured');
 
-    const { data, error } = await supabase
-      .from('tokens')
-      .select('value')
-      .eq('key', key)
-      .eq('created_by', userId)
-      .single();
-    
-    if (error) return null;
-    return data?.value || null;
+    try {
+      const { data, error } = await withTimeout(
+        supabase
+          .from('tokens')
+          .select('value')
+          .eq('key', key)
+          .eq('created_by', userId)
+          .single()
+      );
+
+      if (error) return null;
+      return data?.value || null;
+    } catch (err: any) {
+      if (err && err.message && err.message.includes('timed out')) {
+        throw err;
+      }
+      console.error('Token fetch error:', err);
+      return null;
+    }
   }
 };
 
@@ -495,27 +513,30 @@ export const bulletinService = {
               updated_at: bulletin.created_at
             };
           } catch (tokenError: any) {
-            // If token retrieval fails, return bulletin with minimal data
-            return {
-              id: bulletin.id,
-              user_id: bulletin.created_by,
-              ward_name: '',
-              date: bulletin.meeting_date,
-              meeting_type: bulletin.meeting_type,
-              theme: '',
-              bishopric_message: '',
-              announcements: [],
-              meetings: [],
-              special_events: [],
-              agenda: [],
-              prayers: {},
-              music_program: {},
-              leadership: {},
-              wardLeadership: [],
-              missionaries: [],
-              created_at: bulletin.created_at,
-              updated_at: bulletin.created_at
-            };
+            if (tokenError?.message && tokenError.message.includes('timed out')) {
+              // If token retrieval times out, return bulletin with minimal data
+              return {
+                id: bulletin.id,
+                user_id: bulletin.created_by,
+                ward_name: '',
+                date: bulletin.meeting_date,
+                meeting_type: bulletin.meeting_type,
+                theme: '',
+                bishopric_message: '',
+                announcements: [],
+                meetings: [],
+                special_events: [],
+                agenda: [],
+                prayers: {},
+                music_program: {},
+                leadership: {},
+                wardLeadership: [],
+                missionaries: [],
+                created_at: bulletin.created_at,
+                updated_at: bulletin.created_at
+              };
+            }
+            throw tokenError;
           }
         })
       );


### PR DESCRIPTION
## Summary
- wrap token save/retrieval in `withTimeout`
- bubble timeout errors up to caller
- on timeout, `getUserBulletins` falls back to minimal data

## Testing
- `npm run lint` *(fails: Cannot fix numerous lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d516fd864832aa43caea4d61bdf3c