### PR TITLE
Add timeout handling for user bulletins

### DIFF
--- a/src/components/SavedBulletinsModal.tsx
+++ b/src/components/SavedBulletinsModal.tsx
@@ -24,7 +24,7 @@ export default function SavedBulletinsModal({
 
   const { data: bulletins = [], isLoading: loading, error } = useQuery({
     queryKey: ['user-bulletins', user?.id],
-    queryFn: () => bulletinService.getUserBulletins(user.id),
+    queryFn: async () => bulletinService.getUserBulletins(user.id),
     enabled: isOpen && !!user
   });
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -440,11 +440,14 @@ export const bulletinService = {
     const localBulletins = this.getFromLocalStorage().filter(b => b.created_by === userId);
     console.log('Local bulletins for user:', userId, localBulletins);
     try {
-      const { data, error } = await supabase
-        .from('bulletins')
-        .select('*')
-        .eq('created_by', userId)
-        .order('created_at', { ascending: false });
+      const { data, error } = await withTimeout(
+        supabase
+          .from('bulletins')
+          .select('*')
+          .eq('created_by', userId)
+          .order('created_at', { ascending: false }),
+        10000
+      );
       
       if (error) {
         if (error.message.includes('infinite recursion')) {
@@ -526,6 +529,10 @@ export const bulletinService = {
       
       return [...bulletinsWithData, ...uniqueLocalBulletins];
     } catch (error: any) {
+      if (error.message === 'Operation timed out') {
+        console.warn('getUserBulletins timed out, returning local bulletins');
+        return localBulletins;
+      }
       console.error('Error fetching bulletins from database:', error);
       console.log('Returning local bulletins only due to database error');
       return localBulletins;


### PR DESCRIPTION
## Summary
- wrap bulletin query in `getUserBulletins` with `withTimeout`
- fallback to local storage if a timeout occurs
- ensure SavedBulletinsModal query handles rejected promises

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d516d3754832abd9f7c74a3626c61