### PR TITLE
Add draft restoration on load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,20 @@ function App() {
   // Add a helper for draft key
   const DRAFT_KEY = 'draft_bulletin';
 
+  // Restore any saved draft on initial load
+  useEffect(() => {
+    const saved = localStorage.getItem(DRAFT_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as BulletinData;
+        setBulletinData(parsed);
+        setHasUnsavedChanges(true);
+      } catch (e) {
+        console.error('Failed to parse saved draft:', e);
+      }
+    }
+  }, []);
+
   const convertDbBulletinToData = (bulletin: any): BulletinData => ({
     wardName: bulletin.ward_name,
     date: bulletin.date,


### PR DESCRIPTION
## Summary
- load `draft_bulletin` from local storage when the app first mounts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d59c1b8a8832a9ea58aed38050059