### PR TITLE
Add sample bulletin copy feature

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About ZionBoard</title>
+    <meta name="description" content="Learn about the ZionBoard project and how it helps you create free digital ward bulletins." />
+    <link rel="canonical" href="https://zionboard.com/about" />
+    <style>
+      body {font-family: Arial, sans-serif; margin: 0; padding: 2rem; line-height: 1.6; color: #1a202c;}
+      header, footer {text-align: center; margin-bottom: 2rem;}
+      nav a {margin: 0 1rem; color: #3b82f6; text-decoration: none;}
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>About ZionBoard</h1>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/features">Features</a>
+        <a href="/why-free">Why It&#39;s Free</a>
+        <a href="/ward-bulletins">Ward Bulletins</a>
+      </nav>
+    </header>
+    <main>
+      <p>ZionBoard began as a simple way to share digital ward bulletins. I wanted an easy tool to create, print, and share bulletins without complicated software. Everything runs in your browser, so your information stays private and secure.</p>
+      <p>The platform is completely independent from ward or stake systems. You don&#39;t need access to any membership data to get started&mdash;just create a bulletin and share it with your ward. Your QR code is permanent and will always point to the latest version of your bulletin, even if you move to a new ward.</p>
+      <p>We offer a growing set of features: reusable bulletin templates, PDF export, and public links for easy sharing. More functionality is coming, and I&#39;m happy to add what you need.</p>
+      <p>If you have suggestions or want additional features, send me an email at <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a>. I would love to hear how you use ZionBoard.</p>
+    </main>
+    <footer>
+      <p>&copy; 2024 ZionBoard</p>
+    </footer>
+  </body>
+</html>

--- a/public/features.html
+++ b/public/features.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZionBoard Features</title>
+    <meta name="description" content="Explore the key features of ZionBoard for creating and sharing ward bulletins." />
+    <link rel="canonical" href="https://zionboard.com/features" />
+    <style>
+      body {font-family: Arial, sans-serif; margin: 0; padding: 2rem; line-height: 1.6; color: #1a202c;}
+      header, footer {text-align: center; margin-bottom: 2rem;}
+      nav a {margin: 0 1rem; color: #3b82f6; text-decoration: none;}
+      ul {list-style-type: disc; margin-left: 1.5rem;}
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>ZionBoard Features</h1>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/why-free">Why It&#39;s Free</a>
+        <a href="/ward-bulletins">Ward Bulletins</a>
+      </nav>
+    </header>
+    <main>
+      <p>ZionBoard helps you build beautiful bulletins quickly. Because it isn&#39;t connected to any ward or stake database, you can start right away and keep using the same link as long as you like. Here are a few of the things you can do:</p>
+      <ul>
+        <li>Create digital bulletins in your browser</li>
+        <li>Print PDFs for members who prefer paper</li>
+        <li>Share a public link or QR code with your ward&mdash;the QR code is yours forever</li>
+        <li>Store multiple bulletins and reuse previous templates</li>
+        <li>Duplicate bulletins to save time on weekly updates</li>
+      </ul>
+      <p>Have ideas for more features? Let me know at <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a>.</p>
+    </main>
+    <footer>
+      <p>&copy; 2024 ZionBoard</p>
+    </footer>
+  </body>
+</html>

--- a/public/ward-bulletins.html
+++ b/public/ward-bulletins.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Digital Ward Bulletins</title>
+    <meta name="description" content="Tips for creating and sharing digital ward bulletins using ZionBoard." />
+    <link rel="canonical" href="https://zionboard.com/ward-bulletins" />
+    <style>
+      body {font-family: Arial, sans-serif; margin: 0; padding: 2rem; line-height: 1.6; color: #1a202c;}
+      header, footer {text-align: center; margin-bottom: 2rem;}
+      nav a {margin: 0 1rem; color: #3b82f6; text-decoration: none;}
+      h2 {margin-top: 2rem;}
+      textarea {width: 100%; max-width: 600px; font-family: monospace; margin-top: 0.5rem;}
+      button {margin-top: 0.5rem; padding: 0.5rem 1rem; background: #3b82f6; color: #fff; border: none; cursor: pointer;}
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Digital Ward Bulletins</h1>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/features">Features</a>
+        <a href="/why-free">Why It&#39;s Free</a>
+      </nav>
+    </header>
+    <main>
+      <p>ZionBoard makes it simple to publish ward bulletins online. Members can scan a QR code or visit your personal link to view each week&#39;s bulletin. You can also print a PDF for those who prefer paper.</p>
+      <h2>Copy a Sample Bulletin</h2>
+      <p>If you need a quick start, copy an existing bulletin and customize it for your ward. The built-in templates make it easy to fill in agenda items, hymns, and announcements.</p>
+      <textarea id="sample-bulletin" rows="12" cols="60" readonly>
+Ward Name: Zion 1st Ward
+Date: July 20, 2024
+Presiding: Bishop Smith
+Conducting: Brother Johnson
+Chorister: Sister Lee
+Organist: Brother Davis
+
+Opening Hymn: 100 - Nearer, My God, to Thee
+Invocation: John Doe
+Sacrament Hymn: 169 - As Now We Take the Sacrament
+Speaker: Jane Doe
+Closing Hymn: 152 - God Be with You Till We Meet Again
+Benediction: Mary Doe
+
+Announcements:
+- Ward picnic next Saturday at 5 PM
+- Youth service project on July 25 at 3 PM
+      </textarea>
+      <br />
+      <button id="copy-bulletin">Copy Bulletin</button>
+      <span id="copy-message" style="color:green; display:none; margin-left:0.5rem;">Copied!</span>
+      <p style="margin-top:1rem;">Email <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a> for help or to request additional features.</p>
+    </main>
+    <footer>
+      <p>&copy; 2024 ZionBoard</p>
+    </footer>
+    <script>
+      const copyBtn = document.getElementById('copy-bulletin');
+      if (copyBtn) {
+        copyBtn.addEventListener('click', () => {
+          const sample = document.getElementById('sample-bulletin');
+          const text = sample && 'value' in sample ? sample.value : '';
+          navigator.clipboard.writeText(text).then(() => {
+            const msg = document.getElementById('copy-message');
+            if (msg) {
+              msg.style.display = 'inline';
+              setTimeout(() => {
+                msg.style.display = 'none';
+              }, 2000);
+            }
+          });
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/public/why-free.html
+++ b/public/why-free.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Why ZionBoard is Free</title>
+    <meta name="description" content="Discover why ZionBoard is offered for free and how you can support the project." />
+    <link rel="canonical" href="https://zionboard.com/why-free" />
+    <style>
+      body {font-family: Arial, sans-serif; margin: 0; padding: 2rem; line-height: 1.6; color: #1a202c;}
+      header, footer {text-align: center; margin-bottom: 2rem;}
+      nav a {margin: 0 1rem; color: #3b82f6; text-decoration: none;}
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Why ZionBoard is Free</h1>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/features">Features</a>
+        <a href="/ward-bulletins">Ward Bulletins</a>
+      </nav>
+    </header>
+    <main>
+      <p>ZionBoard is a labor of love. I built it to simplify the way wards share announcements and sacrament meeting details. By keeping it free, anyone can create a digital bulletin without barriers.</p>
+      <p>If you like the project and want to see new features, send a message to <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a>. Your feedback helps shape the future of ZionBoard.</p>
+    </main>
+    <footer>
+      <p>&copy; 2024 ZionBoard</p>
+    </footer>
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "rewrites": [
+    { "source": "/about", "destination": "/about.html" },
+    { "source": "/features", "destination": "/features.html" },
+    { "source": "/why-free", "destination": "/why-free.html" },
+    { "source": "/ward-bulletins", "destination": "/ward-bulletins.html" },
+    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "functions": {
@@ -8,4 +13,4 @@
       "maxDuration": 10
     }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- implement copy to clipboard on Ward Bulletins page
- add SEO pages about ZionBoard
- expand About and Features pages with more detail

## Testing
- `npm run lint` *(fails: ESLint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d91af766c832aba8ebabc060f101f