### PR TITLE
Update footer year and sample bulletin to 2025

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -29,7 +29,7 @@
       <p>If you have suggestions or want additional features, send me an email at <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a>. I would love to hear how you use ZionBoard.</p>
     </main>
     <footer>
-      <p>&copy; 2024 ZionBoard</p>
+      <p>&copy; 2025 ZionBoard</p>
     </footer>
   </body>
 </html>

--- a/public/features.html
+++ b/public/features.html
@@ -35,7 +35,7 @@
       <p>Have ideas for more features? Let me know at <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a>.</p>
     </main>
     <footer>
-      <p>&copy; 2024 ZionBoard</p>
+      <p>&copy; 2025 ZionBoard</p>
     </footer>
   </body>
 </html>

--- a/public/ward-bulletins.html
+++ b/public/ward-bulletins.html
@@ -31,7 +31,7 @@
       <p>If you need a quick start, copy an existing bulletin and customize it for your ward. The built-in templates make it easy to fill in agenda items, hymns, and announcements.</p>
       <textarea id="sample-bulletin" rows="12" cols="60" readonly>
 Ward Name: Zion 1st Ward
-Date: July 20, 2024
+Date: July 20, 2025
 Presiding: Bishop Smith
 Conducting: Brother Johnson
 Chorister: Sister Lee
@@ -54,7 +54,7 @@ Announcements:
       <p style="margin-top:1rem;">Email <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a> for help or to request additional features.</p>
     </main>
     <footer>
-      <p>&copy; 2024 ZionBoard</p>
+      <p>&copy; 2025 ZionBoard</p>
     </footer>
     <script>
       const copyBtn = document.getElementById('copy-bulletin');

--- a/public/why-free.html
+++ b/public/why-free.html
@@ -27,7 +27,7 @@
       <p>If you like the project and want to see new features, send a message to <a href="mailto:matthew@zionboard.com">matthew@zionboard.com</a>. Your feedback helps shape the future of ZionBoard.</p>
     </main>
     <footer>
-      <p>&copy; 2024 ZionBoard</p>
+      <p>&copy; 2025 ZionBoard</p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- bump footer copyright year to 2025
- update ward bulletin example date to 2025

## Testing
- `npm run lint` *(fails: 'User' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687da4221f68832aaa19293b8c7053e3